### PR TITLE
Ensure that the css directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all: build_css compile_translations
 build_css: $(generated_css_files)
 
 $(generated_css_files): snikket_web/static/css/%.css: snikket_web/scss/%.scss $(scss_includes)
+	mkdir -p snikket_web/static/css/
 	$(SCSSC) -o "$@" "$<"
 
 clean:


### PR DESCRIPTION
It isn’t part of the repository, so the Makefile should not rely
on it being present.

Fixes #19.