### PR TITLE
[Docker] Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.7-slim-buster
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    make \
+    && apt-get clean
+
+COPY Makefile /opt/snikket-web-portal/Makefile
+
+COPY requirements.txt /opt/snikket-web-portal/requirements.txt
+
+COPY build-requirements.txt /opt/snikket-web-portal/build-requirements.txt
+
+COPY snikket_web/ /opt/snikket-web-portal/snikket_web
+
+COPY babel.cfg /opt/snikket-web-portal/babel.cfg
+
+COPY web_config.production.py /opt/snikket-web-portal/.local/web_config.py
+
+WORKDIR /opt/snikket-web-portal
+
+RUN pip install -r requirements.txt \
+    && pip install -r build-requirements.txt
+
+RUN make
+
+ENV SNIKKET_WEB_CONFIG "/opt/snikket-web-portal/.local/web_config.py"
+
+RUN pip install hypercorn
+
+ADD docker/entrypoint.sh /bin/entrypoint.sh
+
+ENTRYPOINT ["/bin/sh", "/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,17 +1,3 @@
 #!/bin/sh
 
-if [ -z "$SNIKKET_DOMAIN" ]; then
-  echo "Please provide SNIKKET_DOMAIN";
-  exit 1;
-fi
-
-if [ -z "$PROSODY_ENDPOINT" ]; then
-  echo "Please provide PROSODY_ENDPOINT";
-  exit 1;
-fi
-
-if [ -z "$SECRET_KEY" ]; then
-  echo "Please provide SECRET_KEY";
-fi
-
 exec hypercorn -b "0.0.0.0:8000" snikket_web:app

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -z "$SNIKKET_DOMAIN" ]; then
+  echo "Please provide SNIKKET_DOMAIN";
+  exit 1;
+fi
+
+if [ -z "$PROSODY_ENDPOINT" ]; then
+  echo "Please provide PROSODY_ENDPOINT";
+  exit 1;
+fi
+
+if [ -z "$SECRET_KEY" ]; then
+  echo "Please provide SECRET_KEY";
+fi
+
+exec hypercorn -b "0.0.0.0:8000" snikket_web:app

--- a/web_config.production.py
+++ b/web_config.production.py
@@ -1,0 +1,54 @@
+# REQUIRED SETTINGS
+# =================
+
+# Secret key used to guard forms and sessions.
+#
+# This must be both reasonably constant and secret. If the secret gets
+# compromised, you can change it (without having to worry about the "constant"
+# requirement).
+#
+# if not constant:
+# - sessions will be lost on each server restart
+#
+# if not secret:
+# - users may be able to forge sessions
+# - attackers may be able to execute things on a properly authenticated user’s
+#   behalf.
+# - other bad things.
+import os
+SECRET_KEY = os.environ['SECRET_KEY']
+
+# URL (without trailing /) of the prosody HTTP server.
+#
+# This must be set for anything to work correctly.
+#
+# NOTE: If this does not point at localhost, it MUST use https. Otherwise,
+# passwords will be transmitted in plaintext through insecure channels.
+PROSODY_ENDPOINT = os.environ['PROSODY_ENDPOINT']
+
+# The domain name of the Snikket server
+#
+# This must be set for login to work correctly.
+SNIKKET_DOMAIN = os.environ['SNIKKET_DOMAIN']
+
+
+# OPTIONAL SETTINGS
+# =================
+
+# How long browers may cache avatars
+#
+# Setting this to zero forces browsers to check if their locally cached copy
+# of an avatar is still up-to-date on every request; if it is, the avatar is
+# not re-transferred.
+#
+# AVATAR_CACHE_TTL = 1800
+
+# Which languages to offer
+#
+# Generally, the web portal will offer all languages it has available. There
+# is little point in restricting this, unless if you’re in a situation where
+# the release you’re on has a terrible translation of a specific language
+# and not offering that language at all is better than having that terrible
+# translation.
+#
+# LANGUAGES = ["de", "en"]

--- a/web_config.production.py
+++ b/web_config.production.py
@@ -16,7 +16,18 @@
 #   behalf.
 # - other bad things.
 import os
-SECRET_KEY = os.environ['SECRET_KEY']
+import sys
+import secrets
+
+try:
+    SECRET_KEY = os.environ['SECRET_KEY']
+except KeyError:
+    print('SECRET_KEY was not provided. It will be automatically generated. '
+          'To avoid losing sessions on each server restart, please provide '
+          'a SECRET_KEY.',
+          file=sys.stderr)
+
+SECRET_KEY = os.environ.get('SECRET_KEY', secrets.token_urlsafe(nbytes=32))
 
 # URL (without trailing /) of the prosody HTTP server.
 #
@@ -24,12 +35,22 @@ SECRET_KEY = os.environ['SECRET_KEY']
 #
 # NOTE: If this does not point at localhost, it MUST use https. Otherwise,
 # passwords will be transmitted in plaintext through insecure channels.
-PROSODY_ENDPOINT = os.environ['PROSODY_ENDPOINT']
+try:
+    PROSODY_ENDPOINT = os.environ['PROSODY_ENDPOINT']
+except KeyError as e:
+    print(f'Environment variable {e} must be set for the web portal to work',
+          file=sys.stderr)
+    sys.exit(2)
 
 # The domain name of the Snikket server
 #
 # This must be set for login to work correctly.
-SNIKKET_DOMAIN = os.environ['SNIKKET_DOMAIN']
+try:
+    SNIKKET_DOMAIN = os.environ['SNIKKET_DOMAIN']
+except KeyError as e:
+    print(f'Environment variable {e} must be set for the web portal to work',
+          file=sys.stderr)
+    sys.exit(2)
 
 
 # OPTIONAL SETTINGS


### PR DESCRIPTION
## Description
Add a Dockerfile to allow to have snikket-web-portal in a Docker container. It can then be added to the docker-compose.yml file and be run next to the Snikket container.

## Explanations
I did not know about Hypercorn, but it seems it is developed by the team of Quart and this is the ASGI your are using here. So, I used Hypercorn as the ASGI production server.

I chose the `python:3.7-slim-buster` Docker image as base because it seems it is the most recent official Python version we can get as `slim-buster` without having to build a custom one.

The entrypoint allows to adapt the configuration file with the integrated environment variables when running the image.

So we can do the following:

Build the image:
```
docker build -t snikket-web-portal -f docker/Dockerfile .
```

Run the image:
```
docker run --rm -it --name snikket_web_portal -p 8080:8000 -e SNIKKET_DOMAIN=snikket.org -e PROSODY_ENDPOINT=http://snikket:5280 snikket-web-portal
Running on 0.0.0.0:8000 over http (CTRL + C to quit)
```

It works:

![Screenshot from 2020-04-29 12-25-21](https://user-images.githubusercontent.com/6884630/80585609-f228e700-8a13-11ea-97ee-9bf8625253d6.png)

However, I did not try the connection to the Prosody server, but I think there should be no issue.