### PR TITLE
Enable Italian translation by default

### DIFF
--- a/snikket_web/__init__.py
+++ b/snikket_web/__init__.py
@@ -149,6 +149,7 @@ class AppConfig:
         "en",
         "fr",
         "id",
+        "it",
         "pl",
     ], converter=autosplit)
     apple_store_url = environ.var("")


### PR DESCRIPTION
The translation is marked as 100% on Weblate, and user testing confirms it works (when manually configured).

Fixes #60 