### PR TITLE
Hint to the browser that the avatar should be PNG

### DIFF
--- a/snikket_web/templates/user_profile.html
+++ b/snikket_web/templates/user_profile.html
@@ -13,7 +13,7 @@
 		{{ form.avatar.label }}
 		<div class="avatar-wrap">
 		{%- call avatar(user_info.address, user_info.avatar_hash ) %}{% endcall -%}
-		{{ form.avatar }}
+		{{ form.avatar(accept="image/png") }}
 		</div>
 	</div>
 	<h3 class="form-title">{% trans %}Visibility{% endtrans %}</h3>


### PR DESCRIPTION
Should result in that the file picker by default only shows PNG files
for selection.