### PR TITLE
Update for switch to datamapper in mod_rest

### DIFF
--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -509,7 +509,7 @@ class ProsodyClient:
         req = {
             "kind": "iq",
             "type": "get",
-            "version": True,
+            "version": {},
             "to": domain,
         }
 


### PR DESCRIPTION
mod_rest after the switch to the new util.datamapper in
https://hg.prosody.im/prosody-modules/rev/073f5397c1d2 does not accept
boolean True as value for the xep-0092 'version' field. An empty object
is equivalent and compatible with both previous and future versions.