### PR TITLE
Open PlayStore app instead of website

### DIFF
--- a/snikket_web/invite.py
+++ b/snikket_web/invite.py
@@ -72,7 +72,7 @@ async def view(id_: str) -> typing.Union[quart.Response,
         )
 
     play_store_url = (
-        "https://play.google.com/store/apps/details?" +
+        "market://details?" +
         urllib.parse.urlencode(
             (
                 ("id", "org.snikket.android"),


### PR DESCRIPTION
This should let Android open the Google PlayStore instead of its website.
I didn't test it with snikket-web-portal, just changed that string, but I use that kind of URL on my website that links to an Android app.

Hope it helps :)