### PR TITLE
Automatically determine version from build info or git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,7 @@ ENV SNIKKET_WEB_PROSODY_ENDPOINT=http://127.0.0.1:5280/
 
 HEALTHCHECK CMD nc -zv ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_INTERFACE:-127.0.0.1} ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_PORT:-5765}
 
+RUN echo "$BUILD_SERIES $BUILD_ID" > /opt/snikket-web-portal/.app_version
+
 ADD docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/snikket_web/__init__.py
+++ b/snikket_web/__init__.py
@@ -21,7 +21,7 @@ from quart import (
 import environ
 
 from . import colour, infra
-from ._version import version, version_info  # noqa:F401
+from ._version import version  # noqa:F401
 
 
 async def proc() -> typing.Dict[str, typing.Any]:

--- a/snikket_web/_version.py
+++ b/snikket_web/_version.py
@@ -1,5 +1,15 @@
-version_info = (0, 2, 1, None)
-version = (
-    ".".join(map(str, version_info[:3])) +
-    (f"-{version_info[3]}" if version_info[3] else "")
-)
+import os
+import subprocess
+
+version = "(unknown)"
+
+if os.path.exists(".app_version"):
+    with open(".app_version") as f:
+        version = f.read().strip()
+elif os.path.exists(".git"):
+    try:
+        version = subprocess.check_output([
+            "git", "describe", "--always"
+        ]).strip().decode("utf8")
+    except OSError:
+        version = "dev (unknown)"


### PR DESCRIPTION
Rather than maintaining a hard-coded version number in the repo (which immediately becomes out of date), read it from a `.app_version` file or (if that's not present) attempt to read from the git repository (if we're in one).