### PR TITLE
admin: Show deleted users in circle members

### DIFF
--- a/snikket_web/admin.py
+++ b/snikket_web/admin.py
@@ -485,21 +485,21 @@ async def edit_circle(id_: str) -> typing.Union[str, quart.Response]:
                 return redirect(url_for(".circles"))
             raise
 
-        users = sorted(
-            await client.list_users(),
-            key=lambda x: x.localpart
-        )
+        users = {
+            user.localpart: user
+            for user in await client.list_users()
+        }
         circle_members = [
-            user for user in users
-            if user.localpart in circle.members
+            (localpart, users.get(localpart))
+            for localpart in sorted(circle.members)
         ]
 
     form = EditCircleForm()
-    form.user_to_add.choices = [
-        (user.localpart, user.localpart)
-        for user in users
-        if user.localpart not in circle.members
-    ]
+    form.user_to_add.choices = sorted(
+        (localpart, localpart)
+        for localpart in users.keys()
+        if localpart not in circle.members
+    )
     valid_users = [x[0] for x in form.user_to_add.choices]
 
     invite_form = InvitePost()

--- a/snikket_web/templates/admin_edit_circle.html
+++ b/snikket_web/templates/admin_edit_circle.html
@@ -1,5 +1,5 @@
 {% extends "admin_app.html" %}
-{% from "library.j2" import form_button, standard_button, value_or_hint, custom_form_button, clipboard_button %}
+{% from "library.j2" import form_button, standard_button, value_or_hint, custom_form_button, clipboard_button, icon %}
 {% block head_lead %}
 {{ super() }}
 {% include "copy-snippet.html" %}
@@ -61,9 +61,16 @@
 		<th>{% trans %}Actions{% endtrans %}</th>
 	</thead>
 	<tbody>
-{%- for member in circle_members -%}
+{%- for localpart, member in circle_members -%}
 		<tr>
-			<td>{{ member.localpart }}</td>
+			<td>
+				{%- if member -%}
+				{{ localpart }}
+				{%- else -%}
+				{{ localpart }}
+				<span class="with-tooltip above" data-tooltip="{% trans %}The user has been deleted from the server.{% endtrans %}"><em> ({% trans %}deleted{% endtrans %})</em></span>
+				{%- endif -%}
+			</td>
 			<td class="collapsible">{% call value_or_hint(member.display_name) %}{% endcall %}</td>
 			<td class="nowrap">
 				{%- call custom_form_button("remove_user", form.action_remove_user.name, member.localpart, class="primary danger", slim=True) -%}

--- a/snikket_web/translations/messages.pot
+++ b/snikket_web/translations/messages.pot
@@ -591,28 +591,37 @@ msgstr ""
 msgid "Circle members"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:70
+#: snikket_web/templates/admin_edit_circle.html:71
+msgid "The user has been deleted from the server."
+msgstr ""
+
+#: snikket_web/templates/admin_edit_circle.html:71
+#: snikket_web/templates/library.j2:108
+msgid "deleted"
+msgstr ""
+
+#: snikket_web/templates/admin_edit_circle.html:77
 #, python-format
 msgid "Remove user %(username)s from circle"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:78
+#: snikket_web/templates/admin_edit_circle.html:85
 msgid "This circle currently has no members."
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:80
+#: snikket_web/templates/admin_edit_circle.html:87
 msgid "Invite more members"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:83
+#: snikket_web/templates/admin_edit_circle.html:90
 msgid "Add existing user"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:94
+#: snikket_web/templates/admin_edit_circle.html:101
 msgid "All users added"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:95
+#: snikket_web/templates/admin_edit_circle.html:102
 msgid "All users on this service are already in this circle."
 msgstr ""
 
@@ -1314,10 +1323,6 @@ msgstr ""
 
 #: snikket_web/templates/library.j2:81
 msgid "Invalid input"
-msgstr ""
-
-#: snikket_web/templates/library.j2:108
-msgid "deleted"
 msgstr ""
 
 #: snikket_web/templates/library.j2:122


### PR DESCRIPTION
This helps with removing those users from circles, to avoid them
popping up in peoples roster again.

Even though removal from a circle also only partially works
(roster entries are for instance not cleared), this helps with
ghost users reappearing all the time.

![deleted](https://user-images.githubusercontent.com/271710/122423650-5c8d4580-cf8e-11eb-84d1-d5d882504f9b.png)
