### PR TITLE
Link to main page after successful registration

### DIFF
--- a/snikket_web/templates/invite_success.html
+++ b/snikket_web/templates/invite_success.html
@@ -15,6 +15,6 @@
 		{% trans %}Copy address{% endtrans %}
 	{%- endcall -%}
 	<p>{% trans %}You can now set up your legacy XMPP client with the above address and the password you chose during registration.{% endtrans %}</p>
-	<p>{% trans %}You can now safely close this page.{% endtrans %}</p>
+	<p>{% trans login_url=url_for('main.login') %}You can now safely close this page, or log in to the web portal to <a href="{{ login_url }}">manage your account</a>.{% endtrans %}</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
Someone who registers via the web might also be interested in proceeding to the web portal. Perhaps it's just me as a developer and/or admin.

Suggestions for proper wording, or better solutions would be appreciated.