### PR TITLE
Remove XMPP URI QR code

### DIFF
--- a/snikket_web/scss/invite.scss
+++ b/snikket_web/scss/invite.scss
@@ -80,60 +80,6 @@ img.fdroid {
 	height: $w-l3;
 }
 
-.tabbox {
-	display: flex;
-	flex-direction: column;
-	margin: $w-l1 0;
-
-	> nav.tabs {
-		display: flex;
-		flex-direction: row;
-
-		> a {
-			display: inline-block;
-			padding: $w-s2;
-			border-top-left-radius: $w-s4;
-			border-top-right-radius: $w-s4;
-
-			&, &:visited {
-				color: inherit;
-				text-decoration: underline;
-				text-decoration-color: $accent-500;
-			}
-
-			&:hover {
-				background: $accent-900;
-				border-color: $accent-800;
-				color: black;
-			}
-
-			&.active {
-				text-decoration: none;
-				background: linear-gradient(0deg, $accent-600, $accent-700);
-				color: $accent-200;
-
-				&:hover, &:focus {
-					background: linear-gradient(0deg, $accent-700, $accent-800);
-				}
-
-				&:active {
-					background: $accent-600;
-				}
-			}
-		}
-	}
-
-	> .tab-pane {
-		display: none;
-		padding: 0 $w-0;
-		background: $accent-900;
-
-		&.active {
-			display: block;
-		}
-	}
-}
-
 .qr {
 	margin: $w-l1 0;
 	display: flex;

--- a/snikket_web/templates/invite_view.html
+++ b/snikket_web/templates/invite_view.html
@@ -56,29 +56,7 @@
 			{%- endcall -%}
 		</header>
 		<p>{% trans %}You can transfer this invite to your mobile device by scanning a code with your camera. You can use either a QR scanner app or the Snikket app itself.{% endtrans %}</p>
-		<div class="tabbox">
-			{#- -#}
-			<nav class="tabs" role="tablist">
-				{#- -#}
-				<a href="#qr-info-url" class="active" role="tab" aria-controls="qr-info-url" aria-selected="true" onclick="select_tab(this); return false;">{% trans %}Using a QR code scanner{% endtrans %}</a>
-				{#- -#}
-				<a href="#qr-info-uri" role="tab" aria-controls="qr-info-uri" aria-selected="false" onclick="select_tab(this); return false;">{% trans %}Using the Snikket app{% endtrans %}</a>
-				{#- -#}
-			</nav>
-			{#- -#}
-			<div id="qr-info-url" class="tab-pane active">
-				<p>{% trans %}Use a <em>QR code</em> scanner on your mobile device to scan the code below:{% endtrans %}</p>
-				<div id="qr-invite-page" data-qrdata="{{ url_for(".view", id_=invite_id, _external=True, _scheme="https") }}" class="qr"></div>
-			</div>
-			{#- -#}
-			<div id="qr-info-uri" class="tab-pane">
-				<img class="float-right" id="tutorial-scan" aria-hidden="true" alt="" src="{{ url_for("static", filename="img/tutorial-scan.png") }}">
-				<p>{% trans %}Install the Snikket app on your mobile device, open it, and tap the 'Scan' button at the top.{% endtrans %}</p>
-				<p>{% trans %}Your camera will turn on. Point it at the square code below until it is within the highlighted square on your screen, and wait until the app recognises it.{% endtrans %}</p>
-				<div id="qr-uri" data-qrdata="{{ invite.xmpp_uri }}" class="qr"></div>
-			</div>
-			{#- -#}
-		</div>
+		<div id="qr-invite-page" data-qrdata="{{ url_for(".view", id_=invite_id, _external=True, _scheme="https") }}" class="qr"></div>
 		{#- -#}
 		{%- call standard_button("close", "#", onclick="close_modal(this.parentNode.parentNode); return false;", class="primary") -%}
 			{% trans %}Close{% endtrans %}

--- a/snikket_web/translations/messages.pot
+++ b/snikket_web/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-06 19:52+0200\n"
+"POT-Creation-Date: 2022-06-07 22:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1079,8 +1079,8 @@ msgstr ""
 #: snikket_web/templates/invite_register.html:16
 #: snikket_web/templates/invite_reset_view.html:21
 #: snikket_web/templates/invite_view.html:41
-#: snikket_web/templates/invite_view.html:106
-#: snikket_web/templates/invite_view.html:134
+#: snikket_web/templates/invite_view.html:84
+#: snikket_web/templates/invite_view.html:112
 msgid "Open the app"
 msgstr ""
 
@@ -1170,7 +1170,6 @@ msgid ""
 msgstr ""
 
 #: snikket_web/templates/invite_reset_view.html:26
-#: snikket_web/templates/invite_view.html:77
 msgid ""
 "Your camera will turn on. Point it at the square code below until it is "
 "within the highlighted square on your screen, and wait until the app "
@@ -1289,7 +1288,7 @@ msgid "Get it on Google Play"
 msgstr ""
 
 #: snikket_web/templates/invite_view.html:30
-#: snikket_web/templates/invite_view.html:102
+#: snikket_web/templates/invite_view.html:80
 msgid "Download on the App Store"
 msgstr ""
 
@@ -1320,11 +1319,11 @@ msgid "Scan invite code"
 msgstr ""
 
 #: snikket_web/templates/invite_view.html:55
-#: snikket_web/templates/invite_view.html:84
-#: snikket_web/templates/invite_view.html:96
-#: snikket_web/templates/invite_view.html:112
-#: snikket_web/templates/invite_view.html:124
-#: snikket_web/templates/invite_view.html:140
+#: snikket_web/templates/invite_view.html:62
+#: snikket_web/templates/invite_view.html:74
+#: snikket_web/templates/invite_view.html:90
+#: snikket_web/templates/invite_view.html:102
+#: snikket_web/templates/invite_view.html:118
 msgid "Close"
 msgstr ""
 
@@ -1335,59 +1334,39 @@ msgid ""
 "itself."
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:63
-msgid "Using a QR code scanner"
-msgstr ""
-
-#: snikket_web/templates/invite_view.html:65
-msgid "Using the Snikket app"
-msgstr ""
-
-#: snikket_web/templates/invite_view.html:70
-msgid ""
-"Use a <em>QR code</em> scanner on your mobile device to scan the code "
-"below:"
-msgstr ""
-
-#: snikket_web/templates/invite_view.html:76
-msgid ""
-"Install the Snikket app on your mobile device, open it, and tap the "
-"'Scan' button at the top."
-msgstr ""
-
-#: snikket_web/templates/invite_view.html:93
+#: snikket_web/templates/invite_view.html:71
 msgid "Install on iOS"
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:99
+#: snikket_web/templates/invite_view.html:77
 msgid ""
 "After downloading Snikket from the App Store, you have to return to this "
 "invite link and tap on \"Open the app\" to proceed."
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:101
+#: snikket_web/templates/invite_view.html:79
 msgid "First download Snikket from the App Store using the button below:"
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:103
-#: snikket_web/templates/invite_view.html:131
+#: snikket_web/templates/invite_view.html:81
+#: snikket_web/templates/invite_view.html:109
 msgid ""
 "After the installation is complete, you can return to this page and tap "
 "the \"Open the app\" button to continue with the setup:"
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:121
-#: snikket_web/templates/invite_view.html:130
+#: snikket_web/templates/invite_view.html:99
+#: snikket_web/templates/invite_view.html:108
 msgid "Install via F-Droid"
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:127
+#: snikket_web/templates/invite_view.html:105
 msgid ""
 "After installing Snikket via F-Droid, you have to return to this invite "
 "link and tap on \"Open the app\" to proceed."
 msgstr ""
 
-#: snikket_web/templates/invite_view.html:129
+#: snikket_web/templates/invite_view.html:107
 msgid "First install Snikket from F-Droid using the button below:"
 msgstr ""
 


### PR DESCRIPTION
At the same time, we can also drop the CSS used for that makeshift tab
box. I always felt a bit uneasy about it, a11y-wise, so it's good
riddance.

Fixes #99.

![Screenshot of new version](https://user-images.githubusercontent.com/271710/137017167-637f3f77-6188-4928-8c7f-12d277dbcbf0.png)
