### PR TITLE
Pin wtforms to 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ hsluv~=0.0.2
 flask-babel~=1.0
 email-validator~=1.1
 environ-config~=20.0
+wtforms~=2.3
 typing-extensions


### PR DESCRIPTION
wtforms 3.0 is incompatible with our code. A separate issue will be
filed to address the incompatibilities, but this should be enough to get
working images out of it.

With 3.x, we're seeing:

```
  File "/home/horazont/Projects/python/snikket-web-portal/snikket_web/main.py", line 35, in LoginForm
    address = wtforms.TextField(
AttributeError: module 'wtforms' has no attribute 'TextField'
```

and the portal fails to start.