### PR TITLE
Fix corner cases of byte number formatting

### DIFF
--- a/snikket_web/infra.py
+++ b/snikket_web/infra.py
@@ -53,7 +53,10 @@ def circle_name(c: typing.Any) -> str:
 
 
 def format_bytes(n: float) -> str:
-    scale = math.floor(math.log(n, 1024))
+    try:
+        scale = max(math.floor(math.log(n, 1024)), 0)
+    except ValueError:
+        scale = 0
     try:
         unit = BYTE_UNIT_SCALE_MAP[scale]
         factor = 1024**scale

--- a/snikket_web/infra.py
+++ b/snikket_web/infra.py
@@ -60,7 +60,7 @@ def format_bytes(n: float) -> str:
     try:
         unit = BYTE_UNIT_SCALE_MAP[scale]
         factor = 1024**scale
-    except ValueError:
+    except IndexError:
         unit = "TiB"
         factor = 1024**4
     if factor > 1:


### PR DESCRIPTION
Found in production. Yes really. Due to some borked LXC integration, my
snikket host reports

```
MemTotal:       9007199254740991 kB
MemFree:        9007199254690591 kB
MemAvailable:   9007199254690591 kB
```

That is more than 1024 TiB, so it tries to go further up in the scale,
which then causes a Guru Meditation because of the uncaught IndexError.