### PR TITLE
Do not show dependency versions even to admins by default

### DIFF
--- a/snikket_web/main.py
+++ b/snikket_web/main.py
@@ -91,24 +91,27 @@ async def login() -> typing.Union[str, quart.Response]:
 @bp.route("/meta/about.html")
 async def about() -> str:
     version = None
+    core_versions = {}
     extra_versions = {}
-
     if current_app.debug or client.is_admin_session:
         version = _version.version
+        try:
+            core_versions["Prosody"] = await client.get_server_version()
+        except quart.exceptions.Unauthorized:
+            core_versions["Prosody"] = "unknown"
+
+    if current_app.debug:
         extra_versions["Quart"] = quart.__version__
         extra_versions["aiohttp"] = aiohttp.__version__
         extra_versions["babel"] = babel.__version__
         extra_versions["wtforms"] = wtforms.__version__
         extra_versions["flask-wtf"] = flask_wtf.__version__
-        try:
-            extra_versions["Prosody"] = await client.get_server_version()
-        except quart.exceptions.Unauthorized:
-            extra_versions["Prosody"] = "unknown"
 
     return await render_template(
         "about.html",
         version=version,
         extra_versions=extra_versions,
+        core_versions=core_versions,
     )
 
 

--- a/snikket_web/templates/about.html
+++ b/snikket_web/templates/about.html
@@ -17,9 +17,12 @@
 		<h3>{% trans %}Trademarks{% endtrans %}</h3>
 		<p>{% trans trademarks_url="https://snikket.org/about/trademarks/" %}“Snikket” and the parrot logo are trademarks of Snikket Community Interest Company. For more information about the trademarks, visit the <a href="{{ trademarks_url }}">Snikket Trademarks information page</a>.{% endtrans %}
 		<h3>{% trans %}Software Versions{% endtrans %}</h3>
-		<pre>Snikket Server
-Domain: {{ config["SNIKKET_DOMAIN"] }}
-Snikket Web Portal{% if version %} ({{ version }}){% endif %}
+		<pre>Domain: {{ config["SNIKKET_DOMAIN"] }}
+Web Portal{% if version %} ({{ version }}){% endif %}
+{%- if core_versions -%}
+{% for name, version in core_versions.items() %}
+{{ name }} ({{ version }}){% endfor %}
+{%- endif -%}
 {%- if extra_versions -%}
 {% for name, version in extra_versions.items() %}
 {{ name }} ({{ version }}){% endfor %}


### PR DESCRIPTION
Dependency versions are generally not useful, unless you are developing
or otherwise outside of a normal release situation: If you are on a
normal release, we can figure out the dep versions by looking at the
docker image.

To reduce the amount of information displayed and the amount of
information which needs to be conveyed in case of problems, we only show
the web portal and prosody versions to admins, unless debug mode is
enabled.

The behaviour that versions are only shown to logged in admins (unless
debug mode is enabled) remains unchanged.

Fixes #115.