### PR TITLE
Add autocomplete hints to password forms

### DIFF
--- a/snikket_web/templates/invite_register.html
+++ b/snikket_web/templates/invite_register.html
@@ -28,12 +28,12 @@
 		</div>
 		<div class="f-ebox">
 			{{ form.password.label }}
-			{{ form.password }}
+			{{ form.password(autocomplete="new-password") }}
 			<p class="field-desc weak">{% trans %}Enter a secure password that you do not use anywhere else.{% endtrans %}</p>
 		</div>
 		<div class="f-ebox">
 			{{ form.password_confirm.label }}
-			{{ form.password_confirm }}
+			{{ form.password_confirm(autocomplete="new-password") }}
 		</div>
 		<div class="f-bbox">
 			{%- call form_button("done", form.action_register, class="primary") -%}{%- endcall -%}

--- a/snikket_web/templates/invite_reset.html
+++ b/snikket_web/templates/invite_reset.html
@@ -17,11 +17,11 @@
 	{%- call render_errors(form) %}{% endcall -%}
 	<div class="f-ebox">
 		{{ form.password.label }}
-		{{ form.password }}
+		{{ form.password(autocomplete="new-password") }}
 	</div>
 	<div class="f-ebox">
 		{{ form.password_confirm.label }}
-		{{ form.password_confirm }}
+		{{ form.password_confirm(autocomplete="new-password") }}
 	</div>
 	<div class="f-bbox">
 		{%- call form_button("passwd", form.action_reset, class="primary") -%}{%- endcall -%}

--- a/snikket_web/templates/user_passwd.html
+++ b/snikket_web/templates/user_passwd.html
@@ -9,15 +9,15 @@
 	{%- endcall -%}
 	<div class="f-ebox">
 		{{ form.current_password.label(class="required") }}
-		{{ form.current_password(class=("has-error" if form.current_password.name in form.errors else "")) }}
+		{{ form.current_password(class=("has-error" if form.current_password.name in form.errors else ""), autocomplete="current-password") }}
 	</div>
 	<div class="f-ebox">
 		{{ form.new_password.label(class="required") }}
-		{{ form.new_password }}
+		{{ form.new_password(autocomplete="new-password") }}
 	</div>
 	<div class="f-ebox">
 		{{ form.new_password_confirm.label(class="required") }}
-		{{ form.new_password_confirm(class=("has-error" if form.new_password_confirm.name in form.errors else "")) }}
+		{{ form.new_password_confirm(class=("has-error" if form.new_password_confirm.name in form.errors else ""), autocomplete="new-password") }}
 	</div>
 	<div class="box warning">
 		<header>{% trans %}Warning{% endtrans %}</header>


### PR DESCRIPTION
This allows user agents to do smart things like filling in the current
password only where it makes sense or integrate nicely with a password
manager.

Fixes #94.