### PR TITLE
Dockerfile: Ensure a compiler is available while pip-installing requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,19 +36,20 @@ ENV SNIKKET_WEB_PROSODY_ENDPOINT=http://127.0.0.1:5280/
 
 HEALTHCHECK CMD nc -zv ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_INTERFACE:-127.0.0.1} ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_PORT:-5765}
 
+COPY requirements.txt /opt/snikket-web-portal/requirements.txt
+
+WORKDIR /opt/snikket-web-portal
+
 RUN set -eu; \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update ; \
     apt-get install -y --no-install-recommends \
-        python3 python3-pip python3-setuptools python3-wheel; \
+        python3 python3-pip python3-setuptools python3-wheel build-essential; \
+    pip3 install -r requirements.txt; \
+    apt-get remove -y --autoremove build-essential; \
     apt-get clean ; rm -rf /var/lib/apt/lists; \
     pip3 install hypercorn; \
     rm -rf /root/.cache;
-
-WORKDIR /opt/snikket-web-portal
-
-COPY requirements.txt /opt/snikket-web-portal/requirements.txt
-RUN set -eu; pip3 install -r requirements.txt; rm -rf /root/.cache;
 
 COPY --from=build /opt/snikket-web-portal/snikket_web/ /opt/snikket-web-portal/snikket_web
 COPY babel.cfg /opt/snikket-web-portal/babel.cfg


### PR DESCRIPTION
Dependencies are not necessarily packaged for all architectures. In some cases
(such as aiohttp, and others, on ARM) pip will attempt to compile the
dependency from scratch. Since switching to multi-stage builds, we have been
installing these without a compiler present which caused the build to fail on
ARM architectures.

This commit temporarily installs build-essential packages while running pip,
then removes them again afterwards.

@horazont Specifically requesting your review because I'm particularly curious some things, such as whether we need to be keeping things like python-setuptools around. I didn't change this behaviour for now, in case it's needed. Also, is hypercorn not in requirements.txt, or why were we (and still are) installing it separately? Now would be a good time to check this whole thing and fix any issues before we merge.