### PR TITLE
Dockerfile: Add dev headers required for building deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN set -eu; \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update ; \
     apt-get install -y --no-install-recommends \
-        python3 python3-pip python3-setuptools python3-wheel build-essential; \
+        python3 python3-pip python3-setuptools python3-wheel build-essential libpython3-dev; \
     pip3 install -r requirements.txt; \
-    apt-get remove -y --autoremove build-essential; \
+    apt-get remove -y --autoremove build-essential libpython3-dev; \
     apt-get clean ; rm -rf /var/lib/apt/lists; \
     pip3 install hypercorn; \
     rm -rf /root/.cache;


### PR DESCRIPTION
This was missing, required to build. Unlike last night's PR I've actually tested this one on an ARM system :)