### PR TITLE
Install netcat in final image instead of build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN set -eu; \
     apt-get install -y --no-install-recommends \
         python3 python3-pip python3-setuptools python3-wheel \
         libpython3-dev \
-        make build-essential \
-        netcat;
+        make build-essential;
 
 COPY requirements.txt /opt/snikket-web-portal/requirements.txt
 COPY build-requirements.txt /opt/snikket-web-portal/build-requirements.txt
@@ -34,8 +33,6 @@ ENV SNIKKET_WEB_PYENV=/etc/snikket-web-portal/env.py
 
 ENV SNIKKET_WEB_PROSODY_ENDPOINT=http://127.0.0.1:5280/
 
-HEALTHCHECK CMD nc -zv ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_INTERFACE:-127.0.0.1} ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_PORT:-5765}
-
 COPY requirements.txt /opt/snikket-web-portal/requirements.txt
 
 WORKDIR /opt/snikket-web-portal
@@ -44,12 +41,14 @@ RUN set -eu; \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update ; \
     apt-get install -y --no-install-recommends \
-        python3 python3-pip python3-setuptools python3-wheel build-essential libpython3-dev; \
+        python3 python3-pip python3-setuptools python3-wheel build-essential libpython3-dev netcat; \
     pip3 install -r requirements.txt; \
     apt-get remove -y --autoremove build-essential libpython3-dev; \
     apt-get clean ; rm -rf /var/lib/apt/lists; \
     pip3 install hypercorn; \
     rm -rf /root/.cache;
+
+HEALTHCHECK CMD nc -zv ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_INTERFACE:-127.0.0.1} ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_PORT:-5765}
 
 COPY --from=build /opt/snikket-web-portal/snikket_web/ /opt/snikket-web-portal/snikket_web
 COPY babel.cfg /opt/snikket-web-portal/babel.cfg


### PR DESCRIPTION
`nc` (from netcat) is required for the healthcheck. In
c1cf6ab1e5f7f9e66d7daf2279d2061d6e02824c, the installation was
erroneously moved to the builder image, instead of the final image, so
it was missing since then from the actual application image, causing it
to always show as unhealthy.

Fixes #126.