### PR TITLE
Add a Back button from export panel for consistency

### DIFF
--- a/snikket_web/templates/user_manage_data.html
+++ b/snikket_web/templates/user_manage_data.html
@@ -11,6 +11,8 @@
 			{% call render_errors(form) %}{% endcall %}
 
 			<div class="f-bbox">
+				{%- call standard_button("back", url_for('.index'), class="tertiary") %}{% trans %}Back{% endtrans %}{% endcall -%}
+
 				<form method="POST">
 					{{ form.csrf_token }}
 					{%- call form_button("download", form.action_export, class="primary") %}{% endcall -%}


### PR DESCRIPTION
The other user related sections all have a Back button so it makes sense that this one ought to have one as well.

![image](https://user-images.githubusercontent.com/197474/154807536-5e2fe91b-1366-465e-b29b-c2834f2b7492.png)
