### PR TITLE
Use english as default language instead of danish

### DIFF
--- a/snikket_web/__init__.py
+++ b/snikket_web/__init__.py
@@ -145,9 +145,13 @@ class AppConfig:
     site_name = environ.var("")
     avatar_cache_ttl = environ.var(1800, converter=int)
     languages = environ.var([
+        # Keep `en` as the first language, because it is used as a fallback
+        # if the language negotiation cannot find another match. It is more
+        # likely that users are able to read english (or find a suitable
+        # online translator) than, for instance, danish.
+        "en",
         "da",
         "de",
-        "en",
         "fr",
         "id",
         "it",


### PR DESCRIPTION
It is more likely that a user for whose language no translation exists
can read english than danish.

The fallback to english was apparently introduced in c58ce845, though it
is possible that `best_match` did that internally before.

Fixes #131.