### PR TITLE
Update WTForms and pin quart version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp~=3.6
-quart~=0.17
-flask-wtf~=0.14
+quart~=0.17,<0.18
+flask-wtf~=1.0
 hsluv~=5.0
 flask-babel~=1.0
 email-validator~=1.1


### PR DESCRIPTION
The quart pin is required to fix an attribute error which otherwise occurs during startup. Hence, this should be a good qualifier to know when it's safe to upgrade.

Note that this is not a problem in Quart, but in flask-WTForms. But downgrading flask-wtforms does not help [1], so we don't revert that uprade.

```
AttributeError: module 'quart.json' has no attribute 'JSONEncoder'
```

   [1]: https://github.com/pallets/quart/issues/163