### PR TITLE
Fix #145 by pinning quart to 0.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp~=3.6
-quart~=0.17
+quart==0.17.0
 flask-wtf~=0.14
 hsluv~=5.0
 flask-babel~=1.0


### PR DESCRIPTION
Search for the error turned up https://github.com/pallets/quart/issues/163#issuecomment-1193811123 so tried the suggestion there. Makes the traceback go away. Don't know why.