### PR TITLE
Update to match new Prosody scope naming scheme

### DIFF
--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -27,8 +27,8 @@ from . import xmpputil
 from .xmpputil import split_jid
 
 
-SCOPE_DEFAULT = "prosody:scope:default"
-SCOPE_ADMIN = "prosody:scope:admin"
+SCOPE_DEFAULT = "prosody:user"
+SCOPE_ADMIN = "prosody:admin"
 
 
 T = typing.TypeVar("T")


### PR DESCRIPTION
Makes portal understand when admin privileges are present on latest Prosody trunk & modules.

Ref https://hg.prosody.im/prosody-modules/rev/5ab134b7e510 and probably other changes to mod_http_oauth2 since (and oh so many changes in Prosody trunk)


Thanks @horazont 