### PR TITLE
Follow new role scheme in Prosody

### DIFF
--- a/snikket_web/admin.py
+++ b/snikket_web/admin.py
@@ -77,7 +77,7 @@ class EditUserForm(BaseForm):
         _l("Access Level"),
         choices=[
             ("prosody:restricted", _("Limited")),
-            ("prosody:normal", _l("Normal user")),
+            ("prosody:user", _l("Normal user")),
             ("prosody:admin", _l("Administrator")),
         ],
     )
@@ -116,7 +116,7 @@ async def edit_user(localpart: str) -> typing.Union[werkzeug.Response, str]:
         await client.update_user(
             localpart,
             display_name=form.display_name.data,
-            roles=[form.role.data],
+            role=form.role.data,
         )
 
         await flash(
@@ -131,7 +131,7 @@ async def edit_user(localpart: str) -> typing.Union[werkzeug.Response, str]:
         if target_user_info.roles:
             form.role.data = target_user_info.roles[0]
         else:
-            form.role.data = "prosody:normal"
+            form.role.data = "prosody:user"
 
     return await render_template(
         "admin_edit_user.html",

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -885,7 +885,7 @@ class ProsodyClient:
             localpart: str,
             *,
             display_name: typing.Optional[str],
-            roles: typing.Optional[typing.Collection[str]],
+            role: typing.Optional[str],
             session: aiohttp.ClientSession,
             ) -> None:
         payload: typing.Dict[str, typing.Any] = {
@@ -893,8 +893,8 @@ class ProsodyClient:
         }
         if display_name is not None:
             payload["display_name"] = display_name
-        if roles is not None:
-            payload["roles"] = list(roles)
+        if role is not None:
+            payload["role"] = role
 
         async with session.put(
                 self._admin_v1_endpoint("/users/{}".format(localpart)),

--- a/snikket_web/templates/admin_edit_user.html
+++ b/snikket_web/templates/admin_edit_user.html
@@ -3,7 +3,7 @@
 {% macro access_level_description(role, caller=None) %}
 {%- if role == "prosody:restricted" -%}
 {% trans %}Limited users can interact with users on the same Snikket service and be members of circles.{% endtrans %}
-{%- elif role == "prosody:normal" -%}
+{%- elif role == "prosody:user" -%}
 {% trans %}Like limited users and can also interact with users on other Snikket services.{% endtrans %}
 {%- elif role == "prosody:admin" -%}
 {% trans %}Like normal users and can access the admin panel in the web portal.{% endtrans %}


### PR DESCRIPTION
Prosody changed its role scheme to only support a single primary role for each user. In addition, the names of the built-in roles have been changed. We thus follow those changes to be compatible with the most recent trunk.

One open question is whether we should switch admin -> operator here, too (operator being a server-wide admin), but so far there's no need to.