### PR TITLE
Fix revokation of token on logout

### DIFF
--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -1162,7 +1162,6 @@ class ProsodyClient:
             self._raise_error_from_response(resp)
             return True
 
-    @autosession
     async def revoke_token(
             self,
             *,
@@ -1176,7 +1175,8 @@ class ProsodyClient:
 
     async def logout(self) -> None:
         try:
-            await self.revoke_token()
+            async with self._plain_session as session:
+                await self.revoke_token(session=session)
         except aiohttp.ClientError:
             self.logger.warn("failed to revoke token!",
                              exc_info=True)


### PR DESCRIPTION
In OAuth 2.0, you don't authenticate with the revocation endpoint using the token you are revoking, but rather the OAuth client credentials.

- [x] Builds
- [x] Runs
- [x] Token gone after logout
- [x] Grant gone after logout (an unused refresh token remain but [is cleaned up later](https://hg.prosody.im/trunk/log?rev=extra(%22topic%22%2c%20%22tokencleanup%22)))