### PR TITLE
Remove broken/needless JS from certain pages

### DIFF
--- a/snikket_web/templates/invite_reset.html
+++ b/snikket_web/templates/invite_reset.html
@@ -7,7 +7,6 @@
 {% block head_lead %}
 {{ super() }}
 <title>{% trans %}Reset your password | Snikket{% endtrans %}</title>
-<script async type="text/javascript" src="{{ url_for("static", filename="js/qrcode.min.js") }}"></script>
 {% endblock %}
 {% block content %}
 <form method="POST"><div class="form layout-expanded">
@@ -27,9 +26,4 @@
 		{%- call form_button("passwd", form.action_reset, class="primary") -%}{%- endcall -%}
 	</div>
 </div></form>
-<script type="text/javascript">
-	var onload = function() {
-		apply_qr_code(document.getElementById("qr-uri"));
-	};
-</script>
 {% endblock %}

--- a/snikket_web/templates/invite_view.html
+++ b/snikket_web/templates/invite_view.html
@@ -134,7 +134,6 @@
 
 	var onload = function() {
 		apply_qr_code(document.getElementById("qr-invite-page"));
-		apply_qr_code(document.getElementById("qr-uri"));
 		var popover_as = document.getElementsByClassName("popover");
 		for (var i = 0; i < popover_as.length; ++i) {
 			var a = popover_as[i];

--- a/snikket_web/translations/messages.pot
+++ b/snikket_web/translations/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-08 12:08+0000\n"
+"POT-Creation-Date: 2023-12-12 18:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: snikket_web/admin.py:69 snikket_web/templates/admin_delete_user.html:10
 #: snikket_web/templates/admin_edit_circle.html:73
@@ -1260,11 +1260,11 @@ msgstr ""
 msgid "Reset your password | Snikket"
 msgstr ""
 
-#: snikket_web/templates/invite_reset.html:15
+#: snikket_web/templates/invite_reset.html:14
 msgid "Reset your password online"
 msgstr ""
 
-#: snikket_web/templates/invite_reset.html:16
+#: snikket_web/templates/invite_reset.html:15
 msgid ""
 "To reset your password online, fill out the fields below and confirm "
 "using the button."


### PR DESCRIPTION
The QR code stuff was throwing a JS exception, and on other pages we don't even use it.