### PR TITLE
Tweak user profile display

### DIFF
--- a/snikket_web/scss/app.scss
+++ b/snikket_web/scss/app.scss
@@ -1304,4 +1304,11 @@ pre.guru-meditation {
 		margin-left: 0.5em;
 	}
 
+	.user-display-name {
+		font-size: 110%;
+	}
+
+	.user-jid {
+		font-size: 90%;
+	}
 }

--- a/snikket_web/templates/admin_edit_circle.html
+++ b/snikket_web/templates/admin_edit_circle.html
@@ -1,5 +1,5 @@
 {% extends "admin_app.html" %}
-{% from "library.j2" import form_button, standard_button, value_or_hint, custom_form_button, clipboard_button, icon %}
+{% from "library.j2" import form_button, standard_button, value_or_hint, custom_form_button, clipboard_button, icon, render_user with context %}
 {% block head_lead %}
 {{ super() }}
 {% include "copy-snippet.html" %}
@@ -71,7 +71,6 @@
 <div class="el-2 elevated"><table>
 	<thead>
 		<th>{% trans %}Login name{% endtrans %}</th>
-		<th class="collapsible">{% trans %}Display name{% endtrans %}</th>
 		<th>{% trans %}Actions{% endtrans %}</th>
 	</thead>
 	<tbody>
@@ -79,13 +78,12 @@
 		<tr>
 			<td>
 				{%- if member -%}
-				{{ localpart }}
+				{%- call render_user(member) -%}{%- endcall -%}
 				{%- else -%}
 				{{ localpart }}
 				<span class="with-tooltip above" data-tooltip="{% trans %}The user has been deleted from the server.{% endtrans %}"><em> ({% trans %}deleted{% endtrans %})</em></span>
 				{%- endif -%}
 			</td>
-			<td class="collapsible">{% call value_or_hint(member.display_name) %}{% endcall %}</td>
 			<td class="nowrap">
 				{%- call custom_form_button("remove_user", form.action_remove_user.name, member.localpart, class="primary danger", slim=True) -%}
 					{% trans username=member.localpart %}Remove user {{ username }} from circle{% endtrans %}

--- a/snikket_web/templates/library.j2
+++ b/snikket_web/templates/library.j2
@@ -25,10 +25,10 @@
 		{%- endif -%}
 	</div>
 	<div class="user-info-container">
-		<div class="user-localpart">{{- user.localpart -}}</div>
 		{%- if user.display_name %}
 		<div class="user-display-name">{{- user.display_name -}}</div>
 		{%- endif %}
+		<div class="user-jid"><span class="user-jid-localpart">{{- user.localpart -}}</span><span class="user-jid-at">@</span><span class="user-jid-domain">{{- config["SNIKKET_DOMAIN"] -}}</span></div>
 	</div>
 </div>
 {%- endmacro -%}

--- a/snikket_web/translations/messages.pot
+++ b/snikket_web/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-12 18:22+0000\n"
+"POT-Creation-Date: 2023-12-15 15:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,7 +23,7 @@ msgid "Login name"
 msgstr ""
 
 #: snikket_web/admin.py:73 snikket_web/templates/admin_delete_user.html:12
-#: snikket_web/templates/admin_edit_circle.html:74 snikket_web/user.py:63
+#: snikket_web/user.py:63
 msgid "Display name"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 
 #: snikket_web/templates/admin_circles.html:15
 #: snikket_web/templates/admin_edit_circle.html:45
-#: snikket_web/templates/admin_edit_circle.html:75
+#: snikket_web/templates/admin_edit_circle.html:74
 #: snikket_web/templates/admin_invites.html:24
 #: snikket_web/templates/admin_users.html:10
 msgid "Actions"
@@ -742,37 +742,37 @@ msgstr ""
 msgid "All members of the circle will see each other in their contact list."
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:85
+#: snikket_web/templates/admin_edit_circle.html:84
 msgid "The user has been deleted from the server."
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:85
+#: snikket_web/templates/admin_edit_circle.html:84
 #: snikket_web/templates/library.j2:131
 msgid "deleted"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:91
+#: snikket_web/templates/admin_edit_circle.html:89
 #, python-format
 msgid "Remove user %(username)s from circle"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:99
+#: snikket_web/templates/admin_edit_circle.html:97
 msgid "This circle currently has no members."
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:101
+#: snikket_web/templates/admin_edit_circle.html:99
 msgid "Invite more members"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:104
+#: snikket_web/templates/admin_edit_circle.html:102
 msgid "Add existing user"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:115
+#: snikket_web/templates/admin_edit_circle.html:113
 msgid "All users added"
 msgstr ""
 
-#: snikket_web/templates/admin_edit_circle.html:116
+#: snikket_web/templates/admin_edit_circle.html:114
 msgid "All users on this service are already in this circle."
 msgstr ""
 


### PR DESCRIPTION
This improves the display of user profiles in e.g. the user listing by showing the display name more prominently than the username, and expanding the username to the whole JID. See commit message for rationale.

It also switches the circle member listing from the old "username only" format to the new "user with avatar" rendering that we are using in the "manage users" section.