### PR TITLE
Fix incomplete translation of Announcement form and Limited user role

### DIFF
--- a/snikket_web/admin.py
+++ b/snikket_web/admin.py
@@ -733,21 +733,21 @@ def get_system_stats() -> typing.MutableMapping[
 
 class AnnouncementForm(BaseForm):
     text = wtforms.StringField(
-        _("Message contents"),
+        _l("Message contents"),
         widget=wtforms.widgets.TextArea(),
         validators=[wtforms.validators.DataRequired()],
     )
 
     online_only = wtforms.BooleanField(
-        _("Only send to online users"),
+        _l("Only send to online users"),
     )
 
     action_post_all = wtforms.SubmitField(
-        _("Post to all users"),
+        _l("Post to all users"),
     )
 
     action_send_preview = wtforms.SubmitField(
-        _("Send preview to yourself"),
+        _l("Send preview to yourself"),
     )
 
 

--- a/snikket_web/admin.py
+++ b/snikket_web/admin.py
@@ -76,7 +76,7 @@ class EditUserForm(BaseForm):
     role = wtforms.RadioField(
         _l("Access Level"),
         choices=[
-            ("prosody:restricted", _("Limited")),
+            ("prosody:restricted", _l("Limited")),
             ("prosody:registered", _l("Normal user")),
             ("prosody:admin", _l("Administrator")),
         ],

--- a/snikket_web/templates/admin_users.html
+++ b/snikket_web/templates/admin_users.html
@@ -27,7 +27,6 @@
 				{%- call action_button("edit", url_for(".edit_user", localpart=user.localpart), class="primary") -%}
 					{% trans user_name=user.localpart %}Edit user {{ user_name }}{% endtrans %}
 				{%- endcall -%}
-				</form>
 			</td>
 		</tr>
 {% endfor %}


### PR DESCRIPTION
Fixes that the _Broadcast message_ form and the _Limited_ role in the user  was not translated, due to mistakenly using `_` (aka `flask_babel.gettext`) instead of `_l` (aka `flask_babel.lazy_gettext`).

Bonus: removal of a stray closing HTML tag without a matching opening tag.