### PR TITLE
Fix password validation

### DIFF
--- a/snikket_web/invite.py
+++ b/snikket_web/invite.py
@@ -116,6 +116,10 @@ class RegisterForm(BaseForm):
 
     password = wtforms.PasswordField(
         _l("Password"),
+        validators=[
+            wtforms.validators.InputRequired(),
+            wtforms.validators.Length(min=10),
+        ],
     )
 
     password_confirm = wtforms.PasswordField(
@@ -184,6 +188,10 @@ async def register(id_: str) -> typing.Union[str, werkzeug.Response]:
 class ResetForm(BaseForm):
     password = wtforms.PasswordField(
         _l("Password"),
+        validators=[
+            wtforms.validators.InputRequired(),
+            wtforms.validators.Length(min=10),
+        ],
     )
 
     password_confirm = wtforms.PasswordField(

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -908,7 +908,7 @@ class ProsodyClient:
                 self.session_address,
                 current_password,
             )
-            await self._xml_iq_call(
+            password_changed = await self._xml_iq_call(
                 session,
                 xmpputil.make_password_change_request(
                     self.session_address,
@@ -919,7 +919,7 @@ class ProsodyClient:
                 },
                 sensitive=True,
             )
-            # TODO: error handling
+            xmpputil.extract_iq_reply(password_changed)
             # TODO: obtain a new token using the new password to allow the
             # server to expire/revoke all tokens on password change.
             self._store_token_in_session(token_info)

--- a/snikket_web/translations/messages.pot
+++ b/snikket_web/translations/messages.pot
@@ -23,7 +23,7 @@ msgid "Login name"
 msgstr ""
 
 #: snikket_web/admin.py:73 snikket_web/templates/admin_delete_user.html:12
-#: snikket_web/user.py:63
+#: snikket_web/user.py:69
 msgid "Display name"
 msgstr ""
 
@@ -280,56 +280,56 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: snikket_web/invite.py:118 snikket_web/invite.py:186 snikket_web/main.py:43
+#: snikket_web/invite.py:118 snikket_web/invite.py:190 snikket_web/main.py:43
 msgid "Password"
 msgstr ""
 
-#: snikket_web/invite.py:122 snikket_web/invite.py:190
+#: snikket_web/invite.py:126 snikket_web/invite.py:198
 msgid "Confirm password"
 msgstr ""
 
-#: snikket_web/invite.py:126 snikket_web/invite.py:194
+#: snikket_web/invite.py:130 snikket_web/invite.py:202
 msgid "The passwords must match."
 msgstr ""
 
-#: snikket_web/invite.py:131
+#: snikket_web/invite.py:135
 msgid "Create account"
 msgstr ""
 
-#: snikket_web/invite.py:158
+#: snikket_web/invite.py:162
 msgid "That username is already taken."
 msgstr ""
 
-#: snikket_web/invite.py:162 snikket_web/invite.py:227
+#: snikket_web/invite.py:166 snikket_web/invite.py:235
 msgid "Registration was declined for unknown reasons."
 msgstr ""
 
-#: snikket_web/invite.py:166
+#: snikket_web/invite.py:170
 msgid "The username is not valid."
 msgstr ""
 
-#: snikket_web/invite.py:199 snikket_web/templates/user_home.html:32
+#: snikket_web/invite.py:207 snikket_web/templates/user_home.html:32
 #: snikket_web/templates/user_passwd.html:29
 msgid "Change password"
 msgstr ""
 
-#: snikket_web/invite.py:246
+#: snikket_web/invite.py:254
 msgid "Account data file"
 msgstr ""
 
-#: snikket_web/invite.py:250
+#: snikket_web/invite.py:258
 msgid "Import data"
 msgstr ""
 
-#: snikket_web/invite.py:271
+#: snikket_web/invite.py:279
 #, python-format
 msgid ""
 "The account data you tried to import is in an unknown format. Please "
 "upload an XML file in XEP-0227 format (provided format: %(mimetype)s)."
 msgstr ""
 
-#: snikket_web/invite.py:291 snikket_web/templates/unauth.html:18
-#: snikket_web/user.py:178
+#: snikket_web/invite.py:299 snikket_web/templates/unauth.html:18
+#: snikket_web/user.py:184
 msgid "Error"
 msgstr ""
 
@@ -357,73 +357,73 @@ msgstr ""
 msgid "New password"
 msgstr ""
 
-#: snikket_web/user.py:39
+#: snikket_web/user.py:42
 msgid "Confirm new password"
 msgstr ""
 
-#: snikket_web/user.py:43
+#: snikket_web/user.py:47
 msgid "The new passwords must match."
 msgstr ""
 
-#: snikket_web/user.py:50
+#: snikket_web/user.py:56
 msgid "Sign out"
 msgstr ""
 
-#: snikket_web/user.py:55
+#: snikket_web/user.py:61
 msgid "Nobody"
 msgstr ""
 
-#: snikket_web/user.py:56
+#: snikket_web/user.py:62
 msgid "Friends only"
 msgstr ""
 
-#: snikket_web/user.py:57
+#: snikket_web/user.py:63
 msgid "Everyone"
 msgstr ""
 
-#: snikket_web/user.py:67
+#: snikket_web/user.py:73
 msgid "Avatar"
 msgstr ""
 
-#: snikket_web/user.py:71
+#: snikket_web/user.py:77
 msgid "Profile visibility"
 msgstr ""
 
-#: snikket_web/user.py:76
+#: snikket_web/user.py:82
 msgid "Update profile"
 msgstr ""
 
-#: snikket_web/user.py:82
+#: snikket_web/user.py:88
 msgid "Account data"
 msgstr ""
 
-#: snikket_web/user.py:86
+#: snikket_web/user.py:92
 msgid "Upload"
 msgstr ""
 
-#: snikket_web/user.py:111
+#: snikket_web/user.py:117
 msgid "Incorrect password."
 msgstr ""
 
-#: snikket_web/user.py:115
+#: snikket_web/user.py:121
 msgid "Password changed"
 msgstr ""
 
-#: snikket_web/user.py:123
+#: snikket_web/user.py:129
 msgid ""
 "The chosen avatar is too big. To be able to upload larger avatars, please"
 " use the app."
 msgstr ""
 
-#: snikket_web/user.py:170
+#: snikket_web/user.py:176
 msgid "Profile updated"
 msgstr ""
 
-#: snikket_web/user.py:184
+#: snikket_web/user.py:190
 msgid "Export"
 msgstr ""
 
-#: snikket_web/user.py:202
+#: snikket_web/user.py:208
 msgid "You currently have no account data to export."
 msgstr ""
 

--- a/snikket_web/user.py
+++ b/snikket_web/user.py
@@ -32,16 +32,22 @@ class ChangePasswordForm(BaseForm):
 
     new_password = wtforms.PasswordField(
         _l("New password"),
-        validators=[wtforms.validators.InputRequired()]
+        validators=[
+            wtforms.validators.InputRequired(),
+            wtforms.validators.Length(min=10),
+        ]
     )
 
     new_password_confirm = wtforms.PasswordField(
         _l("Confirm new password"),
-        validators=[wtforms.validators.InputRequired(),
-                    wtforms.validators.EqualTo(
-                        "new_password",
-                        _l("The new passwords must match.")
-                    )]
+        validators=[
+            wtforms.validators.InputRequired(),
+            wtforms.validators.EqualTo(
+                "new_password",
+                _l("The new passwords must match.")
+            ),
+            wtforms.validators.Length(min=10),
+        ]
     )
 
 


### PR DESCRIPTION
An issue was discovered by @Zash where changing the password might fail, but give the user no feedback that it had failed. This could lead to a user thinking their password has been changed, when in fact it has not.

The first commit adds error handling. It's not the best (it throws an XMPP error condition at the user with no explanation), but hopefully we can improve it in the future.

The main reason a password change might fail is because it doesn't meet the policies enforce by the server. For example, if it is too short. The second commit adds some pre-validation before we send it to the server to catch the most common policy violations.