### PR TITLE
templates: Fix typo in closing form tag

### DIFF
--- a/snikket_web/templates/login.html
+++ b/snikket_web/templates/login.html
@@ -30,7 +30,7 @@
 		<div class="f-bbox">
 			{%- call form_button("login", form.action_signin, class="primary") -%}{% endcall -%}
 		</div>
-	</from>
+	</form>
 	<script type="text/javascript">
 var domainCheck = function() {
 	var form = document.getElementById("login-form");


### PR DESCRIPTION
This typo managed to lurk unnoticed since the initial commit. I guess it didn't cause any harm, but it's time to fix it!