### PR TITLE
Specify a default role in invite form

### DIFF
--- a/snikket_web/admin.py
+++ b/snikket_web/admin.py
@@ -80,6 +80,7 @@ class EditUserForm(BaseForm):
             ("prosody:registered", _l("Normal user")),
             ("prosody:admin", _l("Administrator")),
         ],
+        default="prosody:registered",
     )
 
     action_save = wtforms.SubmitField(


### PR DESCRIPTION
The role creation appears to fail without an error, only refreshing the page unless a role is selected.