### PR TITLE
Explicitly set cookie SameSite attribute to Lax

### DIFF
--- a/snikket_web/__init__.py
+++ b/snikket_web/__init__.py
@@ -213,6 +213,7 @@ def create_app() -> quart.Quart:
     app.config["ABUSE_EMAIL"] = config.abuse_email
     app.config["SECURITY_EMAIL"] = config.security_email
     app.config["SESSION_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 
     app.context_processor(proc)
     app.register_error_handler(


### PR DESCRIPTION
With 'Secure' set, it may default to 'None', which we don't need or want.

'Strict' is not suitable for session cookies - the user would see the login screen when navigating from another site (e.g. hosting dashboard) and we already have CSRF protection on forms.