### PR TITLE
OAuth tweaks

### DIFF
--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -473,7 +473,7 @@ class ProsodyClient:
                 "https://{}/login_result".format(current_app.config["SNIKKET_DOMAIN"])
             ],
             "grant_types": ["password"],
-            "response_types": ["code"],
+            "response_types": [],
             "scope": " ".join([SCOPE_RESTRICTED, SCOPE_DEFAULT, SCOPE_ADMIN]),
             "software_version": _version.version,
         }

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -474,6 +474,7 @@ class ProsodyClient:
             ],
             "grant_types": ["password"],
             "response_types": [],
+            "token_endpoint_auth_method": "client_secret_post",
             "scope": " ".join([SCOPE_RESTRICTED, SCOPE_DEFAULT, SCOPE_ADMIN]),
             "software_version": _version.version,
         }

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -474,6 +474,7 @@ class ProsodyClient:
             ],
             "grant_types": ["password"],
             "response_types": ["code"],
+            "scope": " ".join([SCOPE_RESTRICTED, SCOPE_DEFAULT, SCOPE_ADMIN]),
             "software_version": _version.version,
         }
         async with self._plain_session as session:

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -29,7 +29,7 @@ from flask import g as _app_ctx_stack
 
 import werkzeug.exceptions
 
-from . import xmpputil
+from . import xmpputil, _version
 from .xmpputil import split_jid
 
 
@@ -474,6 +474,7 @@ class ProsodyClient:
             ],
             "grant_types": ["password"],
             "response_types": ["code"],
+            "software_version": _version.version,
         }
         async with self._plain_session as session:
             async with session.post(

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -477,6 +477,7 @@ class ProsodyClient:
             "response_types": [],
             "token_endpoint_auth_method": "client_secret_post",
             "scope": " ".join([SCOPE_RESTRICTED, SCOPE_DEFAULT, SCOPE_ADMIN]),
+            "software_id": "22aa246e-4373-51cb-bcaa-9f73bb235b84",  # web-portal.snikket.org
             "software_version": _version.version,
         }
         async with self._plain_session as session:

--- a/snikket_web/prosodyclient.py
+++ b/snikket_web/prosodyclient.py
@@ -472,6 +472,7 @@ class ProsodyClient:
             "redirect_uris": [
                 "https://{}/login_result".format(current_app.config["SNIKKET_DOMAIN"])
             ],
+            "application_type": "web",
             "grant_types": ["password"],
             "response_types": [],
             "token_endpoint_auth_method": "client_secret_post",


### PR DESCRIPTION
Varyingly pedantic tweaks to the OAuth client registration data.

- Include web portal version in oauth client registration
- Include requested scopes in oauth client registration
- Declare use of no response types, since password grant uses none
- Declare that oauth client credentials are using POST method
- Declare as a web application in oauth client registration
- Include a software id in oauth client registration
