### PR TITLE
Dockerfile: Remove health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ RUN set -eu; \
     apt-get clean ; rm -rf /var/lib/apt/lists; \
     rm -rf /root/.cache;
 
-HEALTHCHECK CMD nc -zv ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_INTERFACE:-127.0.0.1} ${SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_PORT:-5765}
-
 COPY --from=build /opt/snikket-web-portal/snikket_web/ /opt/snikket-web-portal/snikket_web
 COPY babel.cfg /opt/snikket-web-portal/babel.cfg
 


### PR DESCRIPTION
To match https://github.com/snikket-im/snikket-server/pull/266 since it
would look wrong if one service has a health check and not the other.
