### PR TITLE
Allow resolving invites from web client

### DIFF
--- a/snikket_web/invite.py
+++ b/snikket_web/invite.py
@@ -115,6 +115,8 @@ async def view(id_: str) -> typing.Union[quart.Response,
         body,
         headers={
             "Link": "<{}>; rel=\"alternate\"".format(invite.xmpp_uri),
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Link",
         }
     )
 


### PR DESCRIPTION
Without these CORS headers a web-based app isn't allowed to fetch the link header for this page.